### PR TITLE
Force usage of HTTP 1.1 even when 2 is available

### DIFF
--- a/src/future/http/HTTPSFuture.php
+++ b/src/future/http/HTTPSFuture.php
@@ -219,6 +219,7 @@ final class HTTPSFuture extends BaseHTTPFuture {
         $allowed_protocols = CURLPROTO_HTTPS | CURLPROTO_HTTP;
         curl_setopt($curl, CURLOPT_PROTOCOLS, $allowed_protocols);
         curl_setopt($curl, CURLOPT_REDIR_PROTOCOLS, $allowed_protocols);
+	curl_setopt($curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
       }
 
       if (strlen($this->rawBody)) {


### PR DESCRIPTION
Catalina upgrades libcurl to version that allows HTTP 2 by default which breaks `arc diff` at Uber.