### PR TITLE
Change priority of autogroup to avoid priority inversion

### DIFF
--- a/scripts/daemon/exec/exec_daemon.php
+++ b/scripts/daemon/exec/exec_daemon.php
@@ -14,6 +14,16 @@ if (!posix_isatty(STDOUT)) {
   if ($sid <= 0) {
     throw new Exception(pht('Failed to create new process session!'));
   }
+  // UBER CODE
+  // if we have lowered process priority then also lower autogroup priority
+  // otherwise it is running at lower priority inside autogroup but actually
+  // at normal priority outside which might cause issues on highly loaded
+  // machines which mix web requests with daemon and on purpose run daemon
+  // at lower priority to improve background processing throughput
+  if (function_exists('pcntl_getpriority') && pcntl_getpriority() != 0) {
+    @file_put_contents('/proc/self/autogroup', ''.pcntl_getpriority());
+  }
+  // UBER CODE END
 }
 
 $args = new PhutilArgumentParser($argv);

--- a/src/daemon/PhutilDaemonOverseer.php
+++ b/src/daemon/PhutilDaemonOverseer.php
@@ -146,7 +146,7 @@ EOHELP
       // machines which mix web requests with daemon and on purpose run daemon
       // at lower priority to improve background processing throughput
       if (pcntl_getpriority() != 0) {
-        @file_put_contents("/proc/self/autogroup", "".pcntl_getpriority());
+        @file_put_contents('/proc/self/autogroup', ''.pcntl_getpriority());
       }
       // UBER CODE END
     }

--- a/src/daemon/PhutilDaemonOverseer.php
+++ b/src/daemon/PhutilDaemonOverseer.php
@@ -145,7 +145,7 @@ EOHELP
       // at normal priority outside which might cause issues on highly loaded
       // machines which mix web requests with daemon and on purpose run daemon
       // at lower priority to improve background processing throughput
-      if (pcntl_getpriority() != 0) {
+      if (function_exists('pcntl_getpriority') && pcntl_getpriority() != 0) {
         @file_put_contents('/proc/self/autogroup', ''.pcntl_getpriority());
       }
       // UBER CODE END

--- a/src/daemon/PhutilDaemonOverseer.php
+++ b/src/daemon/PhutilDaemonOverseer.php
@@ -139,6 +139,16 @@ EOHELP
       if ($sid <= 0) {
         throw new Exception(pht('Failed to create new process session!'));
       }
+      // UBER CODE
+      // if we have lowered process priority then also lower autogroup priority
+      // otherwise it is running at lower priority inside autogroup but actually
+      // at normal priority outside which might cause issues on highly loaded
+      // machines which mix web requests with daemon and on purpose run daemon
+      // at lower priority to improve background processing throughput
+      if (pcntl_getpriority() != 0) {
+        @file_put_contents("/proc/self/autogroup", "".pcntl_getpriority());
+      }
+      // UBER CODE END
     }
 
     $this->logMessage(


### PR DESCRIPTION
Phabricator all web daemons are in one autogroup while each phabricator daemon is in it is own. By default autogroup is normal priority so essentially whole "web process tree" competes against N worker daemons although we want daemons to be prioritized in favor of web.