### PR TITLE
Suppress PHP 8 deprecation warning in __libphutil_init_script__

### DIFF
--- a/scripts/__init_script__.php
+++ b/scripts/__init_script__.php
@@ -80,8 +80,11 @@ function __phutil_init_script__() {
   )));
 
   // Disable the insanely dangerous XML entity loader by default.
+  // PHP 8 deprecates this function and disables this by default; remove once
+  // PHP 7 is no longer supported or a future version has removed the function
+  // entirely.
   if (function_exists('libxml_disable_entity_loader')) {
-    libxml_disable_entity_loader(true);
+    @libxml_disable_entity_loader(true);
   }
 
   // Now, load libphutil.


### PR DESCRIPTION
As of PHP 8, the XML entity loader is disabled by default and the
libxml_disable_entity_loader function is deprecated. Thus suppress the
deprecation warning for now; we could skip the function call, but this
is safer.