### PR TITLE
Remove final from private functions for PHP 8 compatibility

### DIFF
--- a/src/utils/AbstractDirectedGraph.php
+++ b/src/utils/AbstractDirectedGraph.php
@@ -318,7 +318,7 @@ abstract class AbstractDirectedGraph extends Phobject {
    *                      which cycle.
    * @task cycle
    */
-  final private function performCycleDetection($node, array $visited) {
+  private function performCycleDetection($node, array $visited) {
     $visited[$node] = true;
     foreach ($this->knownNodes[$node] as $edge) {
       if (isset($visited[$edge])) {


### PR DESCRIPTION
This combination does not make sense and PHP 8 errors with:

```
Private methods cannot be final as they are never overridden by other classes
```

Thus remove the redundant final from all such functions.