### PR TITLE
php-8.2-upgrade for arcanist

### DIFF
--- a/src/error/PhutilErrorHandler.php
+++ b/src/error/PhutilErrorHandler.php
@@ -350,7 +350,7 @@ final class PhutilErrorHandler extends Phobject {
    * @task internal
    */
   public static function dispatchErrorMessage($event, $value, $metadata) {
-    $timestamp = strftime('%Y-%m-%d %H:%M:%S');
+    $timestamp = date('Y-m-d H:i:s');
 
     switch ($event) {
       case self::ERROR:

--- a/src/future/exec/ExecFuture.php
+++ b/src/future/exec/ExecFuture.php
@@ -751,14 +751,17 @@ final class ExecFuture extends PhutilExecutableFuture {
     $max_stdout_read_bytes = PHP_INT_MAX;
     $max_stderr_read_bytes = PHP_INT_MAX;
     if ($read_buffer_size !== null) {
-      $max_stdout_read_bytes = $read_buffer_size - strlen($this->stdout);
-      $max_stderr_read_bytes = $read_buffer_size - strlen($this->stderr);
+      $stdout_len = $this->getStdoutBufferLength();
+      $stderr_len = $this->getStderrBufferLength();
+
+      $max_stdout_read_bytes = $read_buffer_size - $stdout_len;
+      $max_stderr_read_bytes = $read_buffer_size - $stderr_len;
     }
 
     if ($max_stdout_read_bytes > 0) {
       $this->stdout .= $this->readAndDiscard(
         $stdout,
-        $this->getStdoutSizeLimit() - strlen($this->stdout),
+        $this->getStdoutSizeLimit() - $this->getStdoutBufferLength(),
         'stdout',
         $max_stdout_read_bytes);
     }
@@ -766,7 +769,7 @@ final class ExecFuture extends PhutilExecutableFuture {
     if ($max_stderr_read_bytes > 0) {
       $this->stderr .= $this->readAndDiscard(
         $stderr,
-        $this->getStderrSizeLimit() - strlen($this->stderr),
+        $this->getStderrSizeLimit() - $this->getStderrBufferLength(),
         'stderr',
         $max_stderr_read_bytes);
     }
@@ -974,6 +977,22 @@ final class ExecFuture extends PhutilExecutableFuture {
         return false;
       }
     }
+  }
+
+  private function getStdoutBufferLength() {
+    if ($this->stdout === null) {
+      return 0;
+    }
+
+    return strlen($this->stdout);
+  }
+
+  private function getStderrBufferLength() {
+    if ($this->stderr === null) {
+      return 0;
+    }
+
+    return strlen($this->stderr);
   }
 
 }

--- a/src/future/http/BaseHTTPFuture.php
+++ b/src/future/http/BaseHTTPFuture.php
@@ -206,12 +206,14 @@ abstract class BaseHTTPFuture extends Future {
    * @task config
    */
   public function getHeaders($filter = null) {
-    $filter = strtolower($filter);
+    if ($filter !== null) {
+      $filter = phutil_utf8_strtolower($filter);
+    }
 
     $result = array();
     foreach ($this->headers as $header) {
       list($name, $value) = $header;
-      if (!$filter || ($filter == strtolower($name))) {
+      if (($filter === null) || ($filter === phutil_utf8_strtolower($name))) {
         $result[] = $header;
       }
     }

--- a/src/future/http/HTTPSFuture.php
+++ b/src/future/http/HTTPSFuture.php
@@ -254,7 +254,7 @@ final class HTTPSFuture extends BaseHTTPFuture {
         curl_setopt($curl, CURLOPT_REDIR_PROTOCOLS, $allowed_protocols);
       }
 
-      if (strlen($this->rawBody)) {
+      if ($this->rawBody !== null) {
         if ($this->getData()) {
           throw new Exception(
             pht(

--- a/src/object/Phobject.php
+++ b/src/object/Phobject.php
@@ -33,22 +33,27 @@ abstract class Phobject implements Iterator {
         get_class($this).'::'.$name));
   }
 
+  #[\ReturnTypeWillChange]
   public function current() {
     $this->throwOnAttemptedIteration();
   }
 
+  #[\ReturnTypeWillChange]
   public function key() {
     $this->throwOnAttemptedIteration();
   }
 
+  #[\ReturnTypeWillChange]
   public function next() {
     $this->throwOnAttemptedIteration();
   }
 
+  #[\ReturnTypeWillChange]
   public function rewind() {
     $this->throwOnAttemptedIteration();
   }
 
+  #[\ReturnTypeWillChange]
   public function valid() {
     $this->throwOnAttemptedIteration();
   }

--- a/src/parser/PhutilURI.php
+++ b/src/parser/PhutilURI.php
@@ -166,19 +166,24 @@ final class PhutilURI extends Phobject {
     if ($this->isGitURI()) {
       $protocol = null;
     } else {
-      if (strlen($auth)) {
+      if ($auth !== null) {
         $protocol = nonempty($this->protocol, 'http');
       }
     }
 
-    if (strlen($protocol) || strlen($auth) || strlen($domain)) {
+    $has_protocol = ($protocol !== null) && strlen($protocol);
+    $has_auth = ($auth !== null);
+    $has_domain = ($domain !== null) && strlen($domain);
+    $has_port = ($port !== null) && strlen($port);
+
+    if ($has_protocol || $has_auth || $has_domain) {
       if ($this->isGitURI()) {
         $prefix = "{$auth}{$domain}";
       } else {
         $prefix = "{$protocol}://{$auth}{$domain}";
       }
 
-      if (strlen($port)) {
+      if ($has_port) {
         $prefix .= ':'.$port;
       }
     }

--- a/src/symbols/PhutilClassMapQuery.php
+++ b/src/symbols/PhutilClassMapQuery.php
@@ -221,8 +221,8 @@ final class PhutilClassMapQuery extends Phobject {
     $unique = $this->uniqueMethod;
     $sort = $this->sortMethod;
 
-    if (strlen($expand)) {
-      if (!strlen($unique)) {
+    if ($expand !== null) {
+      if ($unique === null) {
         throw new Exception(
           pht(
             'Trying to execute a class map query for descendants of class '.
@@ -239,7 +239,7 @@ final class PhutilClassMapQuery extends Phobject {
       ->loadObjects();
 
     // Apply the "expand" mechanism, if it is configured.
-    if (strlen($expand)) {
+    if ($expand !== null) {
       $list = array();
       foreach ($objects as $object) {
         foreach (call_user_func(array($object, $expand)) as $instance) {
@@ -251,7 +251,7 @@ final class PhutilClassMapQuery extends Phobject {
     }
 
     // Apply the "unique" mechanism, if it is configured.
-    if (strlen($unique)) {
+    if ($unique !== null) {
       $map = array();
       foreach ($list as $object) {
         $key = call_user_func(array($object, $unique));
@@ -281,12 +281,12 @@ final class PhutilClassMapQuery extends Phobject {
     }
 
     // Apply the "filter" mechanism, if it is configured.
-    if (strlen($filter)) {
+    if ($filter !== null) {
       $map = mfilter($map, $filter);
     }
 
     // Apply the "sort" mechanism, if it is configured.
-    if (strlen($sort)) {
+    if ($sort !== null) {
       if ($map) {
         // The "sort" method may return scalars (which we want to sort with
         // "msort()"), or may return PhutilSortVector objects (which we want

--- a/src/utils/PhutilArray.php
+++ b/src/utils/PhutilArray.php
@@ -28,7 +28,7 @@ abstract class PhutilArray
 
 /* -(  Countable Interface  )------------------------------------------------ */
 
-
+  #[\ReturnTypeWillChange]
   public function count() {
     return count($this->data);
   }
@@ -36,23 +36,27 @@ abstract class PhutilArray
 
 /* -(  Iterator Interface  )------------------------------------------------- */
 
-
+  #[\ReturnTypeWillChange]
   public function current() {
     return current($this->data);
   }
 
+  #[\ReturnTypeWillChange]
   public function key() {
     return key($this->data);
   }
 
+  #[\ReturnTypeWillChange]
   public function next() {
     return next($this->data);
   }
 
+  #[\ReturnTypeWillChange]
   public function rewind() {
     reset($this->data);
   }
 
+  #[\ReturnTypeWillChange]
   public function valid() {
     return (key($this->data) !== null);
   }
@@ -61,18 +65,22 @@ abstract class PhutilArray
 /* -(  ArrayAccess Interface  )---------------------------------------------- */
 
 
+  #[\ReturnTypeWillChange]  
   public function offsetExists($key) {
     return array_key_exists($key, $this->data);
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($key) {
     return $this->data[$key];
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($key, $value) {
     $this->data[$key] = $value;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($key) {
     unset($this->data[$key]);
   }

--- a/src/utils/utf8.php
+++ b/src/utils/utf8.php
@@ -282,6 +282,8 @@ function phutil_utf8_strlen($string) {
  * @return  int     The console display length of the string.
  */
 function phutil_utf8_console_strlen($string) {
+  $string = phutil_string_cast($string);
+  
   // Formatting and colors don't contribute any width in the console.
   $string = preg_replace("/\x1B\[\d*m/", '', $string);
 


### PR DESCRIPTION
Various methods require null check for string utils and others have been deprecated, Hence all changes are adding null check or replacing them with alternate option to upgrade it to PHP-8.2