### PR TITLE
Fix error on adding new type of event

### DIFF
--- a/src/serviceprofiler/PhutilServiceProfiler.php
+++ b/src/serviceprofiler/PhutilServiceProfiler.php
@@ -117,6 +117,9 @@ final class PhutilServiceProfiler extends Phobject {
           }
           $desc = implode('; ', $desc);
           break;
+        case 'unit':
+          $desc = $data['engine'];
+          break;
         case 'exec':
           $desc = '$ '.$data['command'];
           break;
@@ -203,6 +206,10 @@ final class PhutilServiceProfiler extends Phobject {
   }
 
   private static function escapeProfilerStringForDisplay($string) {
+    if (empty($string)) {
+      return $string;
+    }
+
     // Convert tabs and newlines to spaces and collapse blocks of whitespace,
     // most often formatting in queries.
     $string = preg_replace('/\s{2,}/', ' ', $string);


### PR DESCRIPTION
Fix error on adding new type of event at [PR#267](https://github.com/uber/arcanist/pull/267) on `escapeProfilerStringForDisplay`

`ERROR 8192: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated at
`

There is log at [L196](https://github.com/uber/libphutil/pull/29/files#diff-1010faec859247643ff9233ae5c6d9458e4d3aefe3953b015760a6aa83f33e0cL196) for each event type when called `beginServiceCall` or `endServiceCall` from `PhutilServiceProfiler::getInstance()`  with `$desc` variable

There are no events without `$desc` [L#105](https://github.com/uber/libphutil/pull/29/files#diff-1010faec859247643ff9233ae5c6d9458e4d3aefe3953b015760a6aa83f33e0cR105):[L#187](https://github.com/uber/libphutil/pull/29/files#diff-1010faec859247643ff9233ae5c6d9458e4d3aefe3953b015760a6aa83f33e0cL187) how result it hide this potential issue when null `$desc` passed to `preg_replace()`.

1. Checked `$desc` is not empty and return it immediately if it's so.
2. Add `$desc` for unit event


