### PR TITLE
codemod php 8.3 -> 8.4 using rector

### DIFF
--- a/src/future/FutureProxy.php
+++ b/src/future/FutureProxy.php
@@ -8,7 +8,7 @@ abstract class FutureProxy extends Future {
 
   private $proxied;
 
-  public function __construct(Future $proxied = null) {
+  public function __construct(?Future $proxied = null) {
     if ($proxied) {
       $this->setProxiedFuture($proxied);
     }

--- a/src/parser/aast/api/AASTNode.php
+++ b/src/parser/aast/api/AASTNode.php
@@ -42,7 +42,7 @@ abstract class AASTNode extends Phobject {
     return $this->parentNode;
   }
 
-  final public function setParentNode(AASTNode $node = null) {
+  final public function setParentNode(?AASTNode $node = null) {
     $this->parentNode = $node;
     return $this;
   }
@@ -51,7 +51,7 @@ abstract class AASTNode extends Phobject {
     return $this->previousSibling;
   }
 
-  final public function setPreviousSibling(AASTNode $node = null) {
+  final public function setPreviousSibling(?AASTNode $node = null) {
     $this->previousSibling = $node;
     return $this;
   }
@@ -60,7 +60,7 @@ abstract class AASTNode extends Phobject {
     return $this->nextSibling;
   }
 
-  final public function setNextSibling(AASTNode $node = null) {
+  final public function setNextSibling(?AASTNode $node = null) {
     $this->nextSibling = $node;
     return $this;
   }


### PR DESCRIPTION
Applying rector codemod to upgrade php8.3 -> php8.4

Here's how I did it:

1) install php composer globally on system
2) added this rector.php file to home directory in project (specifies the [ExplicitNullableParamTypeRector](https://github.com/rectorphp/rector/blob/aff937886fc1bd7605bdc6f8d750174a15d890cf/docs/rector_rules_overview.md#php84) codemod):
```
<?php

use Rector\Config\RectorConfig;
use Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector;

return RectorConfig::configure()
  ->withPaths([
    __DIR__ . '/src',
    __DIR__ . '/scripts',
  ])
  ->withRules([
    ExplicitNullableParamTypeRector::class
  ]);
```
3) ran `~/.composer/vendor/bin/rector process` to apply codemods