### PR TITLE
Disable curl verbose for php@8.4.12

### DIFF
--- a/src/future/http/HTTPSFuture.php
+++ b/src/future/http/HTTPSFuture.php
@@ -239,6 +239,7 @@ final class HTTPSFuture extends BaseHTTPFuture {
       curl_multi_add_handle(self::$multi, $curl);
 
       curl_setopt($curl, CURLOPT_URL, $uri);
+      curl_setopt($ch, CURLOPT_VERBOSE, false);
 
       if (defined('CURLOPT_PROTOCOLS')) {
         // cURL supports a lot of protocols, and by default it will honor


### PR DESCRIPTION
In php 8.4.12, php libcurl has been giving verbose output.

**Without `CURLOPT_VERBOSE` flag,**
```
% cat test.php 
#!/usr/bin/env php

<?php
$ch = curl_init("https://httpbin.org/get");
$response = curl_exec($ch);
curl_close($ch);
echo $response;

 % php --version    
PHP 8.4.12 (cli) (built: Aug 26 2025 13:36:28) (NTS)
Copyright (c) The PHP Group
Built by Homebrew
Zend Engine v4.4.12, Copyright (c) Zend Technologies
    with Zend OPcache v8.4.12, Copyright (c), by Zend Technologies
preetam@preetam-N5097G7Q63 ~ % ./test.php 

* Host httpbin.org:443 was resolved.
* IPv6: (none)
* IPv4: 34.238.12.187
*   Trying 34.238.12.187:443...
* ALPN: curl offers h2,http/1.1
*  CAfile: /opt/homebrew/etc/openssl@3/cert.pem
*  CApath: none
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384 / secp256r1 / RSASSA-PSS
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=httpbin.org; O=Zscaler Inc.; OU=Zscaler Inc.
*  start date: Sep 12 14:25:16 2025 GMT
*  expire date: Sep 20 04:10:36 2025 GMT
*  subjectAltName: host "httpbin.org" matched cert's "httpbin.org"
*  issuer: C=US; ST=California; O=Zscaler Inc.; OU=Zscaler Inc.; CN="Zscaler Intermediate Root CA (zscalertwo.net) (t) "
*  SSL certificate verify ok.
*   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
*   Certificate level 1: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
*   Certificate level 2: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
*   Certificate level 3: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
* Established connection to httpbin.org (34.238.12.187 port 443) from 100.64.0.1 port 53644 
* using HTTP/1.x
> GET /get HTTP/1.1
Host: httpbin.org
Accept: */*

* Request completely sent off
< HTTP/1.1 200 OK
< Date: Fri, 12 Sep 2025 16:28:13 GMT
< Content-Type: application/json
< Content-Length: 238
< Connection: keep-alive
< Server: gunicorn/19.9.0
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Credentials: true
< 
{
  "args": {}, 
  "headers": {
    "Accept": "*/*", 
    "Host": "httpbin.org", 
    "X-Amzn-Trace-Id": "Root=1-68c44a1b-77c5eed05c6e157c501b3482"
  }, 
  "origin": "174.164.243.10, 136.226.54.170", 
  "url": "https://httpbin.org/get"
}
* Connection #0 to host httpbin.org:443 left intact
```


**With `CURLOPT_VERBOSE` flag,**

```
preetam@preetam-N5097G7Q63 ~ % cat test.php 
#!/usr/bin/env php

<?php

$ch = curl_init("https://httpbin.org/get");
curl_setopt($ch, CURLOPT_VERBOSE, false);
$response = curl_exec($ch);
curl_close($ch);
echo $response;



preetam@preetam-N5097G7Q63 ~ % ./test.php 
{
  "args": {}, 
  "headers": {
    "Accept": "*/*", 
    "Host": "httpbin.org", 
    "X-Amzn-Trace-Id": "Root=1-68c44c0d-130467c151b931b119129bb7"
  }, 
  "origin": "174.164.243.10, 136.226.54.170", 
  "url": "https://httpbin.org/get"
}
```
