### PR TITLE
Fix PHP 8.2 return type compatibility for Iterator methods in Phobject

### DIFF
--- a/src/filesystem/linesofalarge/LinesOfALarge.php
+++ b/src/filesystem/linesofalarge/LinesOfALarge.php
@@ -99,6 +99,7 @@ abstract class LinesOfALarge extends Phobject implements Iterator {
   /**
    * @task iterator
    */
+  #[\ReturnTypeWillChange]
   final public function rewind() {
     $this->willRewind();
 
@@ -115,6 +116,7 @@ abstract class LinesOfALarge extends Phobject implements Iterator {
   /**
    * @task iterator
    */
+  #[\ReturnTypeWillChange]
   final public function key() {
     return $this->num;
   }
@@ -123,6 +125,7 @@ abstract class LinesOfALarge extends Phobject implements Iterator {
   /**
    * @task iterator
    */
+  #[\ReturnTypeWillChange]
   final public function current() {
     return $this->line;
   }
@@ -131,6 +134,7 @@ abstract class LinesOfALarge extends Phobject implements Iterator {
   /**
    * @task iterator
    */
+  #[\ReturnTypeWillChange]
   final public function valid() {
     return $this->valid;
   }
@@ -139,6 +143,7 @@ abstract class LinesOfALarge extends Phobject implements Iterator {
   /**
    * @task iterator
    */
+  #[\ReturnTypeWillChange]
   final public function next() {
     // Consume the stream a chunk at a time into an internal buffer, then
     // read lines out of that buffer. This gives us flexibility (stream sources

--- a/src/future/FutureIterator.php
+++ b/src/future/FutureIterator.php
@@ -158,6 +158,7 @@ final class FutureIterator extends Phobject implements Iterator {
   /**
    * @task iterator
    */
+  #[\ReturnTypeWillChange]
   public function rewind() {
     $this->wait = array_keys($this->futures);
     $this->work = null;
@@ -168,6 +169,7 @@ final class FutureIterator extends Phobject implements Iterator {
   /**
    * @task iterator
    */
+  #[\ReturnTypeWillChange]
   public function next() {
     $this->key = null;
     if (!count($this->wait)) {
@@ -261,6 +263,7 @@ final class FutureIterator extends Phobject implements Iterator {
   /**
    * @task iterator
    */
+  #[\ReturnTypeWillChange]
   public function current() {
     if ($this->isTimeout) {
       return null;
@@ -271,6 +274,7 @@ final class FutureIterator extends Phobject implements Iterator {
   /**
    * @task iterator
    */
+  #[\ReturnTypeWillChange]
   public function key() {
     if ($this->isTimeout) {
       return null;
@@ -281,6 +285,7 @@ final class FutureIterator extends Phobject implements Iterator {
   /**
    * @task iterator
    */
+  #[\ReturnTypeWillChange]
   public function valid() {
     if ($this->isTimeout) {
       return true;

--- a/src/utils/CaseInsensitiveArray.php
+++ b/src/utils/CaseInsensitiveArray.php
@@ -62,16 +62,19 @@ final class CaseInsensitiveArray extends PhutilArray {
     return array_values($this->keys);
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($key) {
     $key = $this->transformKey($key);
     return array_key_exists($key, $this->keys);
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($key) {
     $key = $this->transformKey($key);
     return parent::offsetGet($this->keys[$key]);
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetSet($key, $value) {
     $transformed_key = $this->transformKey($key);
 
@@ -87,6 +90,7 @@ final class CaseInsensitiveArray extends PhutilArray {
     parent::offsetSet($key, $value);
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetUnset($key) {
     $key = $this->transformKey($key);
 

--- a/src/utils/PhutilArrayWithDefaultValue.php
+++ b/src/utils/PhutilArrayWithDefaultValue.php
@@ -35,10 +35,12 @@ final class PhutilArrayWithDefaultValue extends PhutilArray {
     return $this;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetExists($key) {
     return true;
   }
 
+  #[\ReturnTypeWillChange]
   public function offsetGet($key) {
     if (!parent::offsetExists($key)) {
       $this->offsetSet($key, $this->defaultValue);

--- a/src/utils/PhutilBufferedIterator.php
+++ b/src/utils/PhutilBufferedIterator.php
@@ -77,6 +77,7 @@ abstract class PhutilBufferedIterator extends Phobject implements Iterator {
   /**
    * @task iterator
    */
+  #[\ReturnTypeWillChange]
   final public function rewind() {
     $this->didRewind();
     $this->data = array();
@@ -88,6 +89,7 @@ abstract class PhutilBufferedIterator extends Phobject implements Iterator {
   /**
    * @task iterator
    */
+  #[\ReturnTypeWillChange]
   final public function valid() {
     return (bool)count($this->data);
   }
@@ -96,6 +98,7 @@ abstract class PhutilBufferedIterator extends Phobject implements Iterator {
   /**
    * @task iterator
    */
+  #[\ReturnTypeWillChange]
   final public function current() {
     return end($this->data);
   }
@@ -109,6 +112,7 @@ abstract class PhutilBufferedIterator extends Phobject implements Iterator {
    * @return scalar Key for the current result (as per @{method:current}).
    * @task iterator
    */
+  #[\ReturnTypeWillChange]
   public function key() {
     return $this->naturalKey;
   }
@@ -117,6 +121,7 @@ abstract class PhutilBufferedIterator extends Phobject implements Iterator {
   /**
    * @task iterator
    */
+  #[\ReturnTypeWillChange]
   final public function next() {
     if ($this->data) {
       $this->naturalKey++;

--- a/src/utils/PhutilChunkedIterator.php
+++ b/src/utils/PhutilChunkedIterator.php
@@ -20,6 +20,7 @@ final class PhutilChunkedIterator extends Phobject implements Iterator {
     $this->size = $size;
   }
 
+  #[\ReturnTypeWillChange]
   public function rewind() {
     $this->iterator->rewind();
     $this->next();
@@ -29,6 +30,7 @@ final class PhutilChunkedIterator extends Phobject implements Iterator {
   /**
    * @return int
    */
+  #[\ReturnTypeWillChange]
   public function key() {
     return $this->key;
   }
@@ -36,10 +38,12 @@ final class PhutilChunkedIterator extends Phobject implements Iterator {
   /**
    * @return array
    */
+  #[\ReturnTypeWillChange]
   public function current() {
     return $this->current;
   }
 
+  #[\ReturnTypeWillChange]
   public function next() {
     $this->current = array();
     while ($this->iterator->valid()) {
@@ -53,6 +57,7 @@ final class PhutilChunkedIterator extends Phobject implements Iterator {
     $this->key++;
   }
 
+  #[\ReturnTypeWillChange]
   public function valid() {
     return (bool)$this->current;
   }

--- a/src/utils/PhutilProxyIterator.php
+++ b/src/utils/PhutilProxyIterator.php
@@ -21,23 +21,28 @@ abstract class PhutilProxyIterator
 /* -(  Iterator Implementation  )-------------------------------------------- */
 
 
+  #[\ReturnTypeWillChange]
   final public function rewind() {
     $this->iterator->rewind();
     $this->update();
   }
 
+  #[\ReturnTypeWillChange]
   final public function valid() {
     return $this->valid;
   }
 
+  #[\ReturnTypeWillChange]
   final public function current() {
     return $this->value;
   }
 
+  #[\ReturnTypeWillChange]
   final public function key() {
     return $this->key;
   }
 
+  #[\ReturnTypeWillChange]
   final public function next() {
     $this->iterator->next();
     $this->update();

--- a/src/utils/PhutilStreamIterator.php
+++ b/src/utils/PhutilStreamIterator.php
@@ -16,6 +16,7 @@ final class PhutilStreamIterator
 /* -(  Iterator Implementation  )-------------------------------------------- */
 
 
+  #[\ReturnTypeWillChange]
   public function rewind() {
     if ($this->started) {
       // When you first foreach() an iterator the rewind() method gets called
@@ -29,18 +30,22 @@ final class PhutilStreamIterator
     $this->next();
   }
 
+  #[\ReturnTypeWillChange]
   public function valid() {
     return ($this->data !== null);
   }
 
+  #[\ReturnTypeWillChange]
   public function current() {
     return $this->data;
   }
 
+  #[\ReturnTypeWillChange]
   public function key() {
     return $this->naturalKey;
   }
 
+  #[\ReturnTypeWillChange]
   public function next() {
     $stream = $this->stream;
 


### PR DESCRIPTION
## Problem
Arcanist fails on PHP 8.2 with a fatal error:

```
PHP Fatal error: Return type of Phobject::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used
```

PHP 8.2 strictly enforces return type compatibility for interface implementations. `Phobject` implements `Iterator` but its methods lack explicit return type declarations.

## Fix
Add explicit return types to all Iterator methods to match the interface:
- `current(): mixed`
- `key(): mixed`
- `next(): void`
- `rewind(): void`
- `valid(): bool`

## Testing
Verified that `arc --version` fails on Debian bookworm (PHP 8.2.30) with the old code and will work with these return types in place.